### PR TITLE
Fix #424, re-add rtems_fxp_attach() to cfe_psp_start.c.

### DIFF
--- a/fsw/pc-rtems/src/cfe_psp_start.c
+++ b/fsw/pc-rtems/src/cfe_psp_start.c
@@ -36,6 +36,8 @@
 #include <rtems/rtems_dhcp_failsafe.h>
 #include <bsp.h>
 
+extern int rtems_fxp_attach(struct rtems_bsdnet_ifconfig *config, int attaching);
+
 /*
 ** cFE includes
 */


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [ ] I reviewed the [Contributing Guide](https://github.com/nasa/PSP/blob/main/CONTRIBUTING.md).
* [ ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #424.

**Testing performed**
Workflows run.

**Expected behavior changes**
Allows cFS to build for RTEMS 5 with OMIT_DEPRECATED=true

**System(s) tested on**
 - Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Dylan Z. Baker/NASA GSFC